### PR TITLE
updates to new-repo.sh

### DIFF
--- a/new-repo.sh
+++ b/new-repo.sh
@@ -18,8 +18,6 @@ gh repo create "${FULL_NAME}" \
   --public \
   --template "${ORG}/${TEMPLATE}"
 
-git clone "git@github.com:${ORG}/${REPO_NAME}.git"
-
 #(
 #  cd "${REPO_NAME}"
 #  SSH_URL=$(gh api "/repos/${ORG}/${REPO_NAME}" | jq -r '.ssh_url')

--- a/new-repo.sh
+++ b/new-repo.sh
@@ -18,14 +18,6 @@ gh repo create "${FULL_NAME}" \
   --public \
   --template "${ORG}/${TEMPLATE}"
 
-#(
-#  cd "${REPO_NAME}"
-#  SSH_URL=$(gh api "/repos/${ORG}/${REPO_NAME}" | jq -r '.ssh_url')
-#  git remote set-url origin "${SSH_URL}"
-#  git pull origin main
-#  git branch --set-upstream-to=origin/main main
-#)
-
 # Apply the defaults
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/defaults.sh"

--- a/new-repo.sh
+++ b/new-repo.sh
@@ -15,17 +15,18 @@ if [[ -z "${REPO_NAME}" ]]; then
 fi
 
 gh repo create "${FULL_NAME}" \
-  --confirm \
   --public \
   --template "${ORG}/${TEMPLATE}"
 
-(
-  cd "${REPO_NAME}"
-  SSH_URL=$(gh api "/repos/${ORG}/${REPO_NAME}" | jq -r '.ssh_url')
-  git remote set-url origin "${SSH_URL}"
-  git pull origin main
-  git branch --set-upstream-to=origin/main main
-)
+git clone "git@github.com:${ORG}/${REPO_NAME}.git"
+
+#(
+#  cd "${REPO_NAME}"
+#  SSH_URL=$(gh api "/repos/${ORG}/${REPO_NAME}" | jq -r '.ssh_url')
+#  git remote set-url origin "${SSH_URL}"
+#  git pull origin main
+#  git branch --set-upstream-to=origin/main main
+#)
 
 # Apply the defaults
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
It seems there was a change to gh-cli where `gh repo create` no longer initiates a local repository. I think we can now skip the step where we configure a local repository as part of this script.